### PR TITLE
Add Spring Boot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # shopping-back
-Proyecto de carrito de compras (Backend)
+
+Este repositorio contiene el esqueleto de un proyecto **Spring Boot** para un sistema de carrito de compras.
+
+## Requisitos
+- Java 17+
+- Maven 3.9+
+- MySQL disponible en `localhost:3306` con base de datos `shopping` y credenciales `root` / `1qaz2wsX`.
+
+## Compilación
+```bash
+mvn clean package
+```
+
+## Ejecución
+```bash
+mvn spring-boot:run
+```
+
+Una vez iniciado, la documentación Swagger estará disponible en `http://localhost:8080/swagger-ui.html`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ahumadamob</groupId>
+    <artifactId>shopping</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>shopping</name>
+    <description>Skeleton project for shopping application</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/ahumadamob/ShoppingApplication.java
+++ b/src/main/java/com/ahumadamob/ShoppingApplication.java
@@ -1,0 +1,12 @@
+package com.ahumadamob;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ShoppingApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ShoppingApplication.class, args);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/shopping?useSSL=false&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=1qaz2wsX
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary
- bootstrap a Spring Boot MVC project called `shopping`
- configure MySQL datasource in `application.properties`
- enable Swagger via springdoc-openapi
- document build and run instructions in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee9e01f4c832faf2d18f49a79aa81