### PR TITLE
Add Producto entity with CRUD support

### DIFF
--- a/src/main/java/com/ahumadamob/common/ResponseUtils.java
+++ b/src/main/java/com/ahumadamob/common/ResponseUtils.java
@@ -2,6 +2,7 @@ package com.ahumadamob.common;
 
 import com.ahumadamob.dto.ApiSuccessResponseDto;
 import com.ahumadamob.dto.CategoriaResponseDto;
+import com.ahumadamob.dto.ProductoResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -59,6 +60,24 @@ public abstract class ResponseUtils {
             CategoriaResponseDto data) {
         ApiSuccessResponseDto<CategoriaResponseDto> response = ApiSuccessResponseDto
                 .<CategoriaResponseDto>builder()
+                .message("Updated")
+                .data(data)
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
+     * "Updated" message and returns a 200 OK response.
+     *
+     * @param data the payload containing the updated resource
+     * @return ResponseEntity containing the standardized updated DTO
+     */
+    public static ResponseEntity<ApiSuccessResponseDto<ProductoResponseDto>> updated(
+            ProductoResponseDto data) {
+        ApiSuccessResponseDto<ProductoResponseDto> response = ApiSuccessResponseDto
+                .<ProductoResponseDto>builder()
                 .message("Updated")
                 .data(data)
                 .timestamp(LocalDateTime.now())

--- a/src/main/java/com/ahumadamob/controller/ProductoController.java
+++ b/src/main/java/com/ahumadamob/controller/ProductoController.java
@@ -1,0 +1,67 @@
+package com.ahumadamob.controller;
+
+import com.ahumadamob.dto.ApiSuccessResponseDto;
+import com.ahumadamob.dto.ProductoRequestDto;
+import com.ahumadamob.dto.ProductoResponseDto;
+import com.ahumadamob.common.ResponseUtils;
+import com.ahumadamob.entity.Producto;
+import com.ahumadamob.mapper.ProductoMapper;
+import com.ahumadamob.service.IProductoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/productos")
+public class ProductoController {
+
+    @Autowired
+    private IProductoService productoService;
+
+    @Autowired
+    private ProductoMapper productoMapper;
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponseDto<List<ProductoResponseDto>>> getAll() {
+        List<Producto> productos = productoService.findAll();
+        List<ProductoResponseDto> dtoList = productos.stream()
+                .map(productoMapper::toResponseDto)
+                .toList();
+        return ResponseUtils.ok(dtoList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<ProductoResponseDto>> getById(@PathVariable Long id) {
+        Producto producto = productoService.findById(id);
+        ProductoResponseDto dto = productoMapper.toResponseDto(producto);
+        return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponseDto<ProductoResponseDto>> create(@Validated @RequestBody ProductoRequestDto productoDto) {
+        Producto producto = productoMapper.toEntity(productoDto);
+        Producto creado = productoService.create(producto);
+        ProductoResponseDto dto = productoMapper.toResponseDto(creado);
+        return ResponseUtils.created(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<ProductoResponseDto>> update(@PathVariable Long id, @Validated @RequestBody ProductoRequestDto productoDto) {
+        productoService.findById(id); // verify existence
+        Producto producto = productoMapper.toEntity(productoDto);
+        producto.setId(id);
+        Producto actualizado = productoService.update(producto);
+        ProductoResponseDto dto = productoMapper.toResponseDto(actualizado);
+        return ResponseUtils.updated(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        productoService.findById(id); // verify existence
+        productoService.deleteById(id);
+        return ResponseUtils.deleted();
+    }
+}

--- a/src/main/java/com/ahumadamob/dto/ProductoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoRequestDto.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductoRequestDto {
+
+    @NotBlank
+    @Size(max = 64)
+    private String nombre;
+
+    @NotNull
+    private Long categoriaId;
+}

--- a/src/main/java/com/ahumadamob/dto/ProductoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoResponseDto.java
@@ -1,0 +1,16 @@
+package com.ahumadamob.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductoResponseDto {
+    private Long id;
+    private String nombre;
+    private CategoriaResponseDto categoria;
+}

--- a/src/main/java/com/ahumadamob/entity/Producto.java
+++ b/src/main/java/com/ahumadamob/entity/Producto.java
@@ -1,0 +1,31 @@
+package com.ahumadamob.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "productos")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Producto extends BaseEntity {
+
+    @Column(name = "nombre", nullable = false, length = 64)
+    @NotBlank
+    @Size(max = 64)
+    private String nombre;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "categoria_id", nullable = false)
+    @NotNull
+    private Categoria categoria;
+}

--- a/src/main/java/com/ahumadamob/mapper/ProductoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/ProductoMapper.java
@@ -1,0 +1,41 @@
+package com.ahumadamob.mapper;
+
+import com.ahumadamob.dto.ProductoRequestDto;
+import com.ahumadamob.dto.ProductoResponseDto;
+import com.ahumadamob.entity.Producto;
+import com.ahumadamob.entity.Categoria;
+import com.ahumadamob.service.ICategoriaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductoMapper {
+
+    @Autowired
+    private ICategoriaService categoriaService;
+
+    @Autowired
+    private CategoriaMapper categoriaMapper;
+
+    public Producto toEntity(ProductoRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Producto producto = new Producto();
+        producto.setNombre(dto.getNombre());
+        Categoria categoria = categoriaService.findById(dto.getCategoriaId());
+        producto.setCategoria(categoria);
+        return producto;
+    }
+
+    public ProductoResponseDto toResponseDto(Producto producto) {
+        if (producto == null) {
+            return null;
+        }
+        ProductoResponseDto dto = new ProductoResponseDto();
+        dto.setId(producto.getId());
+        dto.setNombre(producto.getNombre());
+        dto.setCategoria(categoriaMapper.toResponseDto(producto.getCategoria()));
+        return dto;
+    }
+}

--- a/src/main/java/com/ahumadamob/repository/ProductoRepository.java
+++ b/src/main/java/com/ahumadamob/repository/ProductoRepository.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.repository;
+
+import com.ahumadamob.entity.Producto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductoRepository extends JpaRepository<Producto, Long> {
+}

--- a/src/main/java/com/ahumadamob/service/IProductoService.java
+++ b/src/main/java/com/ahumadamob/service/IProductoService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.service;
+
+import com.ahumadamob.entity.Producto;
+
+import java.util.List;
+
+public interface IProductoService {
+    List<Producto> findAll();
+    Producto findById(Long id);
+    Producto create(Producto producto);
+    Producto update(Producto producto);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/service/jpa/ProductoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/ProductoServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.service.jpa;
+
+import com.ahumadamob.entity.Producto;
+import com.ahumadamob.exception.EntityNotFoundException;
+import com.ahumadamob.repository.ProductoRepository;
+import com.ahumadamob.service.IProductoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductoServiceImpl implements IProductoService {
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Override
+    public List<Producto> findAll() {
+        return productoRepository.findAll();
+    }
+
+    @Override
+    public Producto findById(Long id) {
+        return productoRepository
+                .findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Producto", id));
+    }
+
+    @Override
+    public Producto create(Producto producto) {
+        return productoRepository.save(producto);
+    }
+
+    @Override
+    public Producto update(Producto producto) {
+        return productoRepository.save(producto);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        productoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Producto` entity with nombre and categoria fields
- create DTOs, mapper, repository, service layer and controller for Producto
- extend `ResponseUtils` with an update method for Producto

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882493b366c832fb94b8c547fb5f176