### PR TITLE
Support multiple categories per product

### DIFF
--- a/src/main/java/com/ahumadamob/dto/ProductoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoRequestDto.java
@@ -1,8 +1,8 @@
 package com.ahumadamob.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +18,5 @@ public class ProductoRequestDto {
     @Size(max = 64)
     private String nombre;
 
-    @NotNull
-    private Long categoriaId;
+    private List<Long> categoriaIds;
 }

--- a/src/main/java/com/ahumadamob/dto/ProductoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -12,5 +13,5 @@ import lombok.NoArgsConstructor;
 public class ProductoResponseDto {
     private Long id;
     private String nombre;
-    private CategoriaResponseDto categoria;
+    private List<CategoriaResponseDto> categorias;
 }

--- a/src/main/java/com/ahumadamob/entity/Producto.java
+++ b/src/main/java/com/ahumadamob/entity/Producto.java
@@ -3,10 +3,13 @@ package com.ahumadamob.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
+import com.ahumadamob.entity.Categoria;
+import java.util.ArrayList;
+import java.util.List;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,8 +27,9 @@ public class Producto extends BaseEntity {
     @Size(max = 64)
     private String nombre;
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "categoria_id", nullable = false)
-    @NotNull
-    private Categoria categoria;
+    @ManyToMany
+    @JoinTable(name = "producto_categorias",
+            joinColumns = @JoinColumn(name = "producto_id"),
+            inverseJoinColumns = @JoinColumn(name = "categoria_id"))
+    private List<Categoria> categorias = new ArrayList<>();
 }

--- a/src/main/java/com/ahumadamob/mapper/ProductoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/ProductoMapper.java
@@ -2,8 +2,10 @@ package com.ahumadamob.mapper;
 
 import com.ahumadamob.dto.ProductoRequestDto;
 import com.ahumadamob.dto.ProductoResponseDto;
+import com.ahumadamob.dto.CategoriaResponseDto;
 import com.ahumadamob.entity.Producto;
 import com.ahumadamob.entity.Categoria;
+import java.util.List;
 import com.ahumadamob.service.ICategoriaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -23,8 +25,12 @@ public class ProductoMapper {
         }
         Producto producto = new Producto();
         producto.setNombre(dto.getNombre());
-        Categoria categoria = categoriaService.findById(dto.getCategoriaId());
-        producto.setCategoria(categoria);
+        if (dto.getCategoriaIds() != null) {
+            List<Categoria> categorias = dto.getCategoriaIds().stream()
+                    .map(categoriaService::findById)
+                    .toList();
+            producto.setCategorias(categorias);
+        }
         return producto;
     }
 
@@ -35,7 +41,10 @@ public class ProductoMapper {
         ProductoResponseDto dto = new ProductoResponseDto();
         dto.setId(producto.getId());
         dto.setNombre(producto.getNombre());
-        dto.setCategoria(categoriaMapper.toResponseDto(producto.getCategoria()));
+        List<CategoriaResponseDto> categorias = producto.getCategorias().stream()
+                .map(categoriaMapper::toResponseDto)
+                .toList();
+        dto.setCategorias(categorias);
         return dto;
     }
 }


### PR DESCRIPTION
## Summary
- allow `Producto` to reference multiple `Categoria`
- accept list of category IDs when creating or updating a product
- return list of categories in product responses
- update mapper to translate between lists and entities

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6886618a0474832f86a8ead6aa095b02