### PR TITLE
Add Picture entity and CRUD endpoints

### DIFF
--- a/src/main/java/com/ahumadamob/common/ResponseUtils.java
+++ b/src/main/java/com/ahumadamob/common/ResponseUtils.java
@@ -4,6 +4,7 @@ import com.ahumadamob.dto.ApiSuccessResponseDto;
 import com.ahumadamob.dto.CategoriaResponseDto;
 import com.ahumadamob.dto.ProductoResponseDto;
 import com.ahumadamob.dto.PictureResponseDto;
+import com.ahumadamob.dto.PictureGalleryResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -97,6 +98,24 @@ public abstract class ResponseUtils {
             PictureResponseDto data) {
         ApiSuccessResponseDto<PictureResponseDto> response = ApiSuccessResponseDto
                 .<PictureResponseDto>builder()
+                .message("Updated")
+                .data(data)
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
+     * "Updated" message and returns a 200 OK response.
+     *
+     * @param data the payload containing the updated resource
+     * @return ResponseEntity containing the standardized updated DTO
+     */
+    public static ResponseEntity<ApiSuccessResponseDto<PictureGalleryResponseDto>> updated(
+            PictureGalleryResponseDto data) {
+        ApiSuccessResponseDto<PictureGalleryResponseDto> response = ApiSuccessResponseDto
+                .<PictureGalleryResponseDto>builder()
                 .message("Updated")
                 .data(data)
                 .timestamp(LocalDateTime.now())

--- a/src/main/java/com/ahumadamob/common/ResponseUtils.java
+++ b/src/main/java/com/ahumadamob/common/ResponseUtils.java
@@ -1,10 +1,6 @@
 package com.ahumadamob.common;
 
 import com.ahumadamob.dto.ApiSuccessResponseDto;
-import com.ahumadamob.dto.CategoriaResponseDto;
-import com.ahumadamob.dto.ProductoResponseDto;
-import com.ahumadamob.dto.PictureResponseDto;
-import com.ahumadamob.dto.PictureGalleryResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -56,66 +52,11 @@ public abstract class ResponseUtils {
      * "Updated" message and returns a 200 OK response.
      *
      * @param data the payload containing the updated resource
+     * @param <T>  the payload type
      * @return ResponseEntity containing the standardized updated DTO
      */
-    public static ResponseEntity<ApiSuccessResponseDto<CategoriaResponseDto>> updated(
-            CategoriaResponseDto data) {
-        ApiSuccessResponseDto<CategoriaResponseDto> response = ApiSuccessResponseDto
-                .<CategoriaResponseDto>builder()
-                .message("Updated")
-                .data(data)
-                .timestamp(LocalDateTime.now())
-                .build();
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
-     * "Updated" message and returns a 200 OK response.
-     *
-     * @param data the payload containing the updated resource
-     * @return ResponseEntity containing the standardized updated DTO
-     */
-    public static ResponseEntity<ApiSuccessResponseDto<ProductoResponseDto>> updated(
-            ProductoResponseDto data) {
-        ApiSuccessResponseDto<ProductoResponseDto> response = ApiSuccessResponseDto
-                .<ProductoResponseDto>builder()
-                .message("Updated")
-                .data(data)
-                .timestamp(LocalDateTime.now())
-                .build();
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
-     * "Updated" message and returns a 200 OK response.
-     *
-     * @param data the payload containing the updated resource
-     * @return ResponseEntity containing the standardized updated DTO
-     */
-    public static ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> updated(
-            PictureResponseDto data) {
-        ApiSuccessResponseDto<PictureResponseDto> response = ApiSuccessResponseDto
-                .<PictureResponseDto>builder()
-                .message("Updated")
-                .data(data)
-                .timestamp(LocalDateTime.now())
-                .build();
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
-     * "Updated" message and returns a 200 OK response.
-     *
-     * @param data the payload containing the updated resource
-     * @return ResponseEntity containing the standardized updated DTO
-     */
-    public static ResponseEntity<ApiSuccessResponseDto<PictureGalleryResponseDto>> updated(
-            PictureGalleryResponseDto data) {
-        ApiSuccessResponseDto<PictureGalleryResponseDto> response = ApiSuccessResponseDto
-                .<PictureGalleryResponseDto>builder()
+    public static <T> ResponseEntity<ApiSuccessResponseDto<T>> updated(T data) {
+        ApiSuccessResponseDto<T> response = ApiSuccessResponseDto.<T>builder()
                 .message("Updated")
                 .data(data)
                 .timestamp(LocalDateTime.now())

--- a/src/main/java/com/ahumadamob/common/ResponseUtils.java
+++ b/src/main/java/com/ahumadamob/common/ResponseUtils.java
@@ -3,6 +3,7 @@ package com.ahumadamob.common;
 import com.ahumadamob.dto.ApiSuccessResponseDto;
 import com.ahumadamob.dto.CategoriaResponseDto;
 import com.ahumadamob.dto.ProductoResponseDto;
+import com.ahumadamob.dto.PictureResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -78,6 +79,24 @@ public abstract class ResponseUtils {
             ProductoResponseDto data) {
         ApiSuccessResponseDto<ProductoResponseDto> response = ApiSuccessResponseDto
                 .<ProductoResponseDto>builder()
+                .message("Updated")
+                .data(data)
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Wraps the given data in an {@link ApiSuccessResponseDto} with an
+     * "Updated" message and returns a 200 OK response.
+     *
+     * @param data the payload containing the updated resource
+     * @return ResponseEntity containing the standardized updated DTO
+     */
+    public static ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> updated(
+            PictureResponseDto data) {
+        ApiSuccessResponseDto<PictureResponseDto> response = ApiSuccessResponseDto
+                .<PictureResponseDto>builder()
                 .message("Updated")
                 .data(data)
                 .timestamp(LocalDateTime.now())

--- a/src/main/java/com/ahumadamob/controller/PictureController.java
+++ b/src/main/java/com/ahumadamob/controller/PictureController.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.controller;
+
+import com.ahumadamob.dto.ApiSuccessResponseDto;
+import com.ahumadamob.dto.PictureRequestDto;
+import com.ahumadamob.dto.PictureResponseDto;
+import com.ahumadamob.common.ResponseUtils;
+import com.ahumadamob.entity.Picture;
+import com.ahumadamob.mapper.PictureMapper;
+import com.ahumadamob.service.IPictureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/pictures")
+@CrossOrigin(origins = "http://localhost:4200")
+public class PictureController {
+
+    @Autowired
+    private IPictureService pictureService;
+
+    @Autowired
+    private PictureMapper pictureMapper;
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponseDto<List<PictureResponseDto>>> getAll() {
+        List<Picture> pictures = pictureService.findAll();
+        List<PictureResponseDto> dtoList = pictures.stream()
+                .map(pictureMapper::toResponseDto)
+                .toList();
+        return ResponseUtils.ok(dtoList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> getById(@PathVariable Long id) {
+        Picture picture = pictureService.findById(id);
+        PictureResponseDto dto = pictureMapper.toResponseDto(picture);
+        return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> create(@Validated @RequestBody PictureRequestDto pictureDto) {
+        Picture picture = pictureMapper.toEntity(pictureDto);
+        Picture created = pictureService.create(picture);
+        PictureResponseDto dto = pictureMapper.toResponseDto(created);
+        return ResponseUtils.created(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> update(@PathVariable Long id, @Validated @RequestBody PictureRequestDto pictureDto) {
+        pictureService.findById(id); // verify existence
+        Picture picture = pictureMapper.toEntity(pictureDto);
+        picture.setId(id);
+        Picture updated = pictureService.update(picture);
+        PictureResponseDto dto = pictureMapper.toResponseDto(updated);
+        return ResponseUtils.updated(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        pictureService.findById(id); // verify existence
+        pictureService.deleteById(id);
+        return ResponseUtils.deleted();
+    }
+}

--- a/src/main/java/com/ahumadamob/controller/PictureGalleryController.java
+++ b/src/main/java/com/ahumadamob/controller/PictureGalleryController.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.controller;
+
+import com.ahumadamob.dto.ApiSuccessResponseDto;
+import com.ahumadamob.dto.PictureGalleryRequestDto;
+import com.ahumadamob.dto.PictureGalleryResponseDto;
+import com.ahumadamob.common.ResponseUtils;
+import com.ahumadamob.entity.PictureGallery;
+import com.ahumadamob.mapper.PictureGalleryMapper;
+import com.ahumadamob.service.IPictureGalleryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/picture-galleries")
+@CrossOrigin(origins = "http://localhost:4200")
+public class PictureGalleryController {
+
+    @Autowired
+    private IPictureGalleryService pictureGalleryService;
+
+    @Autowired
+    private PictureGalleryMapper pictureGalleryMapper;
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponseDto<List<PictureGalleryResponseDto>>> getAll() {
+        List<PictureGallery> galleries = pictureGalleryService.findAll();
+        List<PictureGalleryResponseDto> dtoList = galleries.stream()
+                .map(pictureGalleryMapper::toResponseDto)
+                .toList();
+        return ResponseUtils.ok(dtoList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<PictureGalleryResponseDto>> getById(@PathVariable Long id) {
+        PictureGallery gallery = pictureGalleryService.findById(id);
+        PictureGalleryResponseDto dto = pictureGalleryMapper.toResponseDto(gallery);
+        return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponseDto<PictureGalleryResponseDto>> create(@Validated @RequestBody PictureGalleryRequestDto galleryDto) {
+        PictureGallery gallery = pictureGalleryMapper.toEntity(galleryDto);
+        PictureGallery created = pictureGalleryService.create(gallery);
+        PictureGalleryResponseDto dto = pictureGalleryMapper.toResponseDto(created);
+        return ResponseUtils.created(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<PictureGalleryResponseDto>> update(@PathVariable Long id, @Validated @RequestBody PictureGalleryRequestDto galleryDto) {
+        pictureGalleryService.findById(id);
+        PictureGallery gallery = pictureGalleryMapper.toEntity(galleryDto);
+        gallery.setId(id);
+        PictureGallery updated = pictureGalleryService.update(gallery);
+        PictureGalleryResponseDto dto = pictureGalleryMapper.toResponseDto(updated);
+        return ResponseUtils.updated(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        pictureGalleryService.findById(id);
+        pictureGalleryService.deleteById(id);
+        return ResponseUtils.deleted();
+    }
+}

--- a/src/main/java/com/ahumadamob/dto/PictureGalleryRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureGalleryRequestDto.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PictureGalleryRequestDto {
+
+    @NotBlank
+    @Size(max = 255)
+    private String description;
+
+    private List<Long> pictureIds;
+}

--- a/src/main/java/com/ahumadamob/dto/PictureGalleryResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureGalleryResponseDto.java
@@ -1,0 +1,18 @@
+package com.ahumadamob.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PictureGalleryResponseDto {
+    private Long id;
+    private String description;
+    private List<PictureResponseDto> pictures;
+}

--- a/src/main/java/com/ahumadamob/dto/PictureRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureRequestDto.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PictureRequestDto {
+
+    @NotBlank
+    @URL
+    private String url;
+
+    @NotBlank
+    @Size(max = 255)
+    private String fileName;
+
+    @NotBlank
+    @Pattern(regexp = "^[\\w.+-]+/[\\w.+-]+$", message = "Formato MIME invalido")
+    private String mimeType;
+
+    @NotNull
+    @Min(1)
+    @Max(5 * 1024 * 1024)
+    private Long size;
+
+    @Min(0)
+    private Integer order;
+
+    @NotNull
+    private Boolean cover = false;
+}

--- a/src/main/java/com/ahumadamob/dto/PictureResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureResponseDto.java
@@ -1,0 +1,23 @@
+package com.ahumadamob.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PictureResponseDto {
+    private Long id;
+    private String url;
+    private String fileName;
+    private String mimeType;
+    private Long size;
+    private Integer order;
+    private Boolean cover;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/com/ahumadamob/entity/Picture.java
+++ b/src/main/java/com/ahumadamob/entity/Picture.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+
+import org.hibernate.validator.constraints.URL;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pictures")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Picture extends BaseEntity {
+
+    @Column(name = "url", nullable = false)
+    @NotBlank
+    @URL
+    private String url;
+
+    @Column(name = "file_name", nullable = false, length = 255)
+    @NotBlank
+    @Size(max = 255)
+    private String fileName;
+
+    @Column(name = "mime_type", nullable = false)
+    @NotBlank
+    @Pattern(regexp = "^[\\w.+-]+/[\\w.+-]+$", message = "Formato MIME invalido")
+    private String mimeType;
+
+    @Column(name = "size", nullable = false)
+    @NotNull
+    @Min(1)
+    @Max(5 * 1024 * 1024)
+    private Long size;
+
+    @Column(name = "ordering")
+    @Min(0)
+    private Integer order;
+
+    @Column(name = "cover", nullable = false)
+    @NotNull
+    private Boolean cover = false;
+
+    @Column(name = "created_date", nullable = false)
+    @NotNull
+    private LocalDateTime createdDate;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdDate == null) {
+            createdDate = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/ahumadamob/entity/PictureGallery.java
+++ b/src/main/java/com/ahumadamob/entity/PictureGallery.java
@@ -1,0 +1,30 @@
+package com.ahumadamob.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "picture_galleries")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PictureGallery extends BaseEntity {
+
+    @Column(name = "description", nullable = false, length = 255)
+    @NotBlank
+    @Size(max = 255)
+    private String description;
+
+    @ManyToMany
+    @JoinTable(name = "picture_gallery_pictures",
+            joinColumns = @JoinColumn(name = "gallery_id"),
+            inverseJoinColumns = @JoinColumn(name = "picture_id"))
+    private List<Picture> pictures = new ArrayList<>();
+}

--- a/src/main/java/com/ahumadamob/mapper/PictureGalleryMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/PictureGalleryMapper.java
@@ -1,0 +1,51 @@
+package com.ahumadamob.mapper;
+
+import com.ahumadamob.dto.PictureGalleryRequestDto;
+import com.ahumadamob.dto.PictureGalleryResponseDto;
+import com.ahumadamob.dto.PictureResponseDto;
+import com.ahumadamob.entity.Picture;
+import com.ahumadamob.entity.PictureGallery;
+import com.ahumadamob.service.IPictureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PictureGalleryMapper {
+
+    @Autowired
+    private IPictureService pictureService;
+
+    @Autowired
+    private PictureMapper pictureMapper;
+
+    public PictureGallery toEntity(PictureGalleryRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        PictureGallery gallery = new PictureGallery();
+        gallery.setDescription(dto.getDescription());
+        if (dto.getPictureIds() != null) {
+            List<Picture> pictures = dto.getPictureIds().stream()
+                    .map(pictureService::findById)
+                    .toList();
+            gallery.setPictures(pictures);
+        }
+        return gallery;
+    }
+
+    public PictureGalleryResponseDto toResponseDto(PictureGallery gallery) {
+        if (gallery == null) {
+            return null;
+        }
+        PictureGalleryResponseDto dto = new PictureGalleryResponseDto();
+        dto.setId(gallery.getId());
+        dto.setDescription(gallery.getDescription());
+        List<PictureResponseDto> pictures = gallery.getPictures().stream()
+                .map(pictureMapper::toResponseDto)
+                .toList();
+        dto.setPictures(pictures);
+        return dto;
+    }
+}

--- a/src/main/java/com/ahumadamob/mapper/PictureMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/PictureMapper.java
@@ -1,0 +1,40 @@
+package com.ahumadamob.mapper;
+
+import com.ahumadamob.dto.PictureRequestDto;
+import com.ahumadamob.dto.PictureResponseDto;
+import com.ahumadamob.entity.Picture;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PictureMapper {
+
+    public Picture toEntity(PictureRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Picture picture = new Picture();
+        picture.setUrl(dto.getUrl());
+        picture.setFileName(dto.getFileName());
+        picture.setMimeType(dto.getMimeType());
+        picture.setSize(dto.getSize());
+        picture.setOrder(dto.getOrder());
+        picture.setCover(dto.getCover());
+        return picture;
+    }
+
+    public PictureResponseDto toResponseDto(Picture picture) {
+        if (picture == null) {
+            return null;
+        }
+        PictureResponseDto dto = new PictureResponseDto();
+        dto.setId(picture.getId());
+        dto.setUrl(picture.getUrl());
+        dto.setFileName(picture.getFileName());
+        dto.setMimeType(picture.getMimeType());
+        dto.setSize(picture.getSize());
+        dto.setOrder(picture.getOrder());
+        dto.setCover(picture.getCover());
+        dto.setCreatedDate(picture.getCreatedDate());
+        return dto;
+    }
+}

--- a/src/main/java/com/ahumadamob/repository/PictureGalleryRepository.java
+++ b/src/main/java/com/ahumadamob/repository/PictureGalleryRepository.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.repository;
+
+import com.ahumadamob.entity.PictureGallery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PictureGalleryRepository extends JpaRepository<PictureGallery, Long> {
+}

--- a/src/main/java/com/ahumadamob/repository/PictureRepository.java
+++ b/src/main/java/com/ahumadamob/repository/PictureRepository.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.repository;
+
+import com.ahumadamob.entity.Picture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PictureRepository extends JpaRepository<Picture, Long> {
+}

--- a/src/main/java/com/ahumadamob/service/IPictureGalleryService.java
+++ b/src/main/java/com/ahumadamob/service/IPictureGalleryService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.service;
+
+import com.ahumadamob.entity.PictureGallery;
+
+import java.util.List;
+
+public interface IPictureGalleryService {
+    List<PictureGallery> findAll();
+    PictureGallery findById(Long id);
+    PictureGallery create(PictureGallery gallery);
+    PictureGallery update(PictureGallery gallery);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/service/IPictureService.java
+++ b/src/main/java/com/ahumadamob/service/IPictureService.java
@@ -1,0 +1,13 @@
+package com.ahumadamob.service;
+
+import com.ahumadamob.entity.Picture;
+
+import java.util.List;
+
+public interface IPictureService {
+    List<Picture> findAll();
+    Picture findById(Long id);
+    Picture create(Picture picture);
+    Picture update(Picture picture);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/service/jpa/PictureGalleryServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/PictureGalleryServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.service.jpa;
+
+import com.ahumadamob.entity.PictureGallery;
+import com.ahumadamob.exception.EntityNotFoundException;
+import com.ahumadamob.repository.PictureGalleryRepository;
+import com.ahumadamob.service.IPictureGalleryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PictureGalleryServiceImpl implements IPictureGalleryService {
+
+    @Autowired
+    private PictureGalleryRepository pictureGalleryRepository;
+
+    @Override
+    public List<PictureGallery> findAll() {
+        return pictureGalleryRepository.findAll();
+    }
+
+    @Override
+    public PictureGallery findById(Long id) {
+        return pictureGalleryRepository
+                .findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("PictureGallery", id));
+    }
+
+    @Override
+    public PictureGallery create(PictureGallery gallery) {
+        return pictureGalleryRepository.save(gallery);
+    }
+
+    @Override
+    public PictureGallery update(PictureGallery gallery) {
+        return pictureGalleryRepository.save(gallery);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        pictureGalleryRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ahumadamob.service.jpa;
+
+import com.ahumadamob.entity.Picture;
+import com.ahumadamob.exception.EntityNotFoundException;
+import com.ahumadamob.repository.PictureRepository;
+import com.ahumadamob.service.IPictureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PictureServiceImpl implements IPictureService {
+
+    @Autowired
+    private PictureRepository pictureRepository;
+
+    @Override
+    public List<Picture> findAll() {
+        return pictureRepository.findAll();
+    }
+
+    @Override
+    public Picture findById(Long id) {
+        return pictureRepository
+                .findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Picture", id));
+    }
+
+    @Override
+    public Picture create(Picture picture) {
+        return pictureRepository.save(picture);
+    }
+
+    @Override
+    public Picture update(Picture picture) {
+        return pictureRepository.save(picture);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        pictureRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement new entity `Picture` with validation rules
- add repository, service interface/impl, mapper, and DTOs for `Picture`
- expose CRUD REST controller for pictures
- extend `ResponseUtils` with helper for `PictureResponseDto`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688b88291154832fbb48163057235a22