### PR TITLE
Add multipart picture upload endpoint and storage

### DIFF
--- a/src/main/java/com/ahumadamob/controller/PictureController.java
+++ b/src/main/java/com/ahumadamob/controller/PictureController.java
@@ -8,9 +8,11 @@ import com.ahumadamob.entity.Picture;
 import com.ahumadamob.mapper.PictureMapper;
 import com.ahumadamob.service.IPictureService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -39,6 +41,16 @@ public class PictureController {
         Picture picture = pictureService.findById(id);
         PictureResponseDto dto = pictureMapper.toResponseDto(picture);
         return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> upload(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "order", required = false) Integer order,
+            @RequestParam(value = "cover", required = false) Boolean cover) {
+        Picture created = pictureService.create(file, order, cover);
+        PictureResponseDto dto = pictureMapper.toResponseDto(created);
+        return ResponseUtils.created(dto);
     }
 
     @PostMapping

--- a/src/main/java/com/ahumadamob/service/IPictureService.java
+++ b/src/main/java/com/ahumadamob/service/IPictureService.java
@@ -1,6 +1,7 @@
 package com.ahumadamob.service;
 
 import com.ahumadamob.entity.Picture;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -8,6 +9,7 @@ public interface IPictureService {
     List<Picture> findAll();
     Picture findById(Long id);
     Picture create(Picture picture);
+    Picture create(MultipartFile file, Integer order, Boolean cover);
     Picture update(Picture picture);
     void deleteById(Long id);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+uploads.dir=uploads


### PR DESCRIPTION
## Summary
- support uploading picture files via `multipart/form-data`
- store uploaded files to configurable directory and persist metadata
- add configuration property for uploads directory

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4fe2d18832fb43b9940fe0b262e