### PR TITLE
feat: store picture path

### DIFF
--- a/src/main/java/com/ahumadamob/dto/PictureRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureRequestDto.java
@@ -23,6 +23,9 @@ public class PictureRequestDto {
     private String url;
 
     @NotBlank
+    private String path;
+
+    @NotBlank
     @Size(max = 255)
     private String fileName;
 

--- a/src/main/java/com/ahumadamob/dto/PictureResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/PictureResponseDto.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class PictureResponseDto {
     private Long id;
     private String url;
+    private String path;
     private String fileName;
     private String mimeType;
     private Long size;

--- a/src/main/java/com/ahumadamob/entity/Picture.java
+++ b/src/main/java/com/ahumadamob/entity/Picture.java
@@ -31,6 +31,10 @@ public class Picture extends BaseEntity {
     @URL
     private String url;
 
+    @Column(name = "path", nullable = false)
+    @NotBlank
+    private String path;
+
     @Column(name = "file_name", nullable = false, length = 255)
     @NotBlank
     @Size(max = 255)

--- a/src/main/java/com/ahumadamob/mapper/PictureMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/PictureMapper.java
@@ -14,6 +14,7 @@ public class PictureMapper {
         }
         Picture picture = new Picture();
         picture.setUrl(dto.getUrl());
+        picture.setPath(dto.getPath());
         picture.setFileName(dto.getFileName());
         picture.setMimeType(dto.getMimeType());
         picture.setSize(dto.getSize());
@@ -29,6 +30,7 @@ public class PictureMapper {
         PictureResponseDto dto = new PictureResponseDto();
         dto.setId(picture.getId());
         dto.setUrl(picture.getUrl());
+        dto.setPath(picture.getPath());
         dto.setFileName(picture.getFileName());
         dto.setMimeType(picture.getMimeType());
         dto.setSize(picture.getSize());

--- a/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
@@ -56,10 +56,11 @@ public class PictureServiceImpl implements IPictureService {
 
         String uniqueName = UUID.randomUUID().toString() + extension;
 
+        Path filePath;
         try {
             Path directory = Paths.get(uploadDir);
             Files.createDirectories(directory);
-            Path filePath = directory.resolve(uniqueName);
+            filePath = directory.resolve(uniqueName);
             file.transferTo(filePath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to store file", e);
@@ -72,6 +73,7 @@ public class PictureServiceImpl implements IPictureService {
 
         Picture picture = new Picture();
         picture.setUrl(url);
+        picture.setPath(filePath.toString());
         picture.setFileName(uniqueName);
         picture.setMimeType(contentType);
         picture.setSize(size);


### PR DESCRIPTION
## Summary
- add path column to Picture entity and expose in DTOs
- map path in PictureMapper and persist on upload

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fc6fea758832f8854da10d6c65b78