### PR TITLE
Add multipart update endpoint for pictures

### DIFF
--- a/src/main/java/com/ahumadamob/controller/PictureController.java
+++ b/src/main/java/com/ahumadamob/controller/PictureController.java
@@ -88,12 +88,13 @@ public class PictureController {
         return ResponseUtils.created(dto);
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> update(@PathVariable Long id, @Validated @RequestBody PictureRequestDto pictureDto) {
-        pictureService.findById(id); // verify existence
-        Picture picture = pictureMapper.toEntity(pictureDto);
-        picture.setId(id);
-        Picture updated = pictureService.update(picture);
+    @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> update(
+            @PathVariable Long id,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "order", required = false) Integer order,
+            @RequestParam(value = "cover", required = false) Boolean cover) {
+        Picture updated = pictureService.update(id, file, order, cover);
         PictureResponseDto dto = pictureMapper.toResponseDto(updated);
         return ResponseUtils.updated(dto);
     }

--- a/src/main/java/com/ahumadamob/service/IPictureService.java
+++ b/src/main/java/com/ahumadamob/service/IPictureService.java
@@ -11,5 +11,6 @@ public interface IPictureService {
     Picture create(Picture picture);
     Picture create(MultipartFile file, Integer order, Boolean cover);
     Picture update(Picture picture);
+    Picture update(Long id, MultipartFile file, Integer order, Boolean cover);
     void deleteById(Long id);
 }


### PR DESCRIPTION
## Summary
- support updating pictures with multipart data, including file, order and cover flags
- implement service layer to replace stored file and update metadata
- expose new update method in picture service API

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890c70912bc832fac706fea678457b9