### PR TITLE
Refactor picture update to reuse create logic

### DIFF
--- a/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
@@ -45,6 +45,47 @@ public class PictureServiceImpl implements IPictureService {
 
     @Override
     public Picture create(MultipartFile file, Integer order, Boolean cover) {
+        Picture picture = storeFile(file);
+        picture.setOrder(order);
+        picture.setCover(cover != null ? cover : false);
+        return pictureRepository.save(picture);
+    }
+
+    @Override
+    public Picture update(Picture picture) {
+        return pictureRepository.save(picture);
+    }
+
+    @Override
+    public Picture update(Long id, MultipartFile file, Integer order, Boolean cover) {
+        Picture existing = findById(id);
+
+        // Remove previous file if it exists
+        if (existing.getPath() != null) {
+            try {
+                Files.deleteIfExists(Paths.get(existing.getPath()));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to delete old file", e);
+            }
+        }
+
+        Picture fileData = storeFile(file);
+        existing.setUrl(fileData.getUrl());
+        existing.setPath(fileData.getPath());
+        existing.setFileName(fileData.getFileName());
+        existing.setMimeType(fileData.getMimeType());
+        existing.setSize(fileData.getSize());
+        if (order != null) {
+            existing.setOrder(order);
+        }
+        if (cover != null) {
+            existing.setCover(cover);
+        }
+
+        return pictureRepository.save(existing);
+    }
+
+    private Picture storeFile(MultipartFile file) {
         String originalFilename = file.getOriginalFilename();
         long size = file.getSize();
         String contentType = file.getContentType();
@@ -77,69 +118,7 @@ public class PictureServiceImpl implements IPictureService {
         picture.setFileName(uniqueName);
         picture.setMimeType(contentType);
         picture.setSize(size);
-        picture.setOrder(order);
-        picture.setCover(cover != null ? cover : false);
-
-        return pictureRepository.save(picture);
-    }
-
-    @Override
-    public Picture update(Picture picture) {
-        return pictureRepository.save(picture);
-    }
-
-    @Override
-    public Picture update(Long id, MultipartFile file, Integer order, Boolean cover) {
-        Picture existing = findById(id);
-
-        // Remove previous file if it exists
-        if (existing.getPath() != null) {
-            try {
-                Files.deleteIfExists(Paths.get(existing.getPath()));
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to delete old file", e);
-            }
-        }
-
-        String originalFilename = file.getOriginalFilename();
-        long size = file.getSize();
-        String contentType = file.getContentType();
-
-        String extension = "";
-        if (originalFilename != null && originalFilename.contains(".")) {
-            extension = originalFilename.substring(originalFilename.lastIndexOf('.'));
-        }
-
-        String uniqueName = UUID.randomUUID().toString() + extension;
-
-        Path filePath;
-        try {
-            Path directory = Paths.get(uploadDir);
-            Files.createDirectories(directory);
-            filePath = directory.resolve(uniqueName);
-            file.transferTo(filePath);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to store file", e);
-        }
-
-        String url = ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/" + uploadDir + "/")
-                .path(uniqueName)
-                .toUriString();
-
-        existing.setUrl(url);
-        existing.setPath(filePath.toString());
-        existing.setFileName(uniqueName);
-        existing.setMimeType(contentType);
-        existing.setSize(size);
-        if (order != null) {
-            existing.setOrder(order);
-        }
-        if (cover != null) {
-            existing.setCover(cover);
-        }
-
-        return pictureRepository.save(existing);
+        return picture;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Extract file storing logic into a helper and reuse it for creating and updating pictures
- Update picture update flow to replace stored file metadata while optionally adjusting order and cover

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6890c7e95a94832fbed7b7783ea6fd3f