### PR TITLE
Refactor picture update to reuse file logic

### DIFF
--- a/src/main/java/com/ahumadamob/controller/PictureController.java
+++ b/src/main/java/com/ahumadamob/controller/PictureController.java
@@ -88,6 +88,10 @@ public class PictureController {
         return ResponseUtils.created(dto);
     }
 
+    /**
+     * Replaces the binary content of an existing picture. Additional fields such as
+     * order or cover flag can also be supplied through multipart form-data.
+     */
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiSuccessResponseDto<PictureResponseDto>> update(
             @PathVariable Long id,

--- a/src/main/java/com/ahumadamob/service/IPictureService.java
+++ b/src/main/java/com/ahumadamob/service/IPictureService.java
@@ -11,6 +11,16 @@ public interface IPictureService {
     Picture create(Picture picture);
     Picture create(MultipartFile file, Integer order, Boolean cover);
     Picture update(Picture picture);
+    /**
+     * Updates an existing {@link Picture} replacing its file and optionally
+     * modifying its order or cover flag.
+     *
+     * @param id    identifier of the picture to update
+     * @param file  new binary content
+     * @param order optional order value
+     * @param cover optional cover flag
+     * @return the persisted picture with updated information
+     */
     Picture update(Long id, MultipartFile file, Integer order, Boolean cover);
     void deleteById(Long id);
 }

--- a/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/PictureServiceImpl.java
@@ -45,9 +45,8 @@ public class PictureServiceImpl implements IPictureService {
 
     @Override
     public Picture create(MultipartFile file, Integer order, Boolean cover) {
-        Picture picture = storeFile(file);
-        picture.setOrder(order);
-        picture.setCover(cover != null ? cover : false);
+        Picture picture = new Picture();
+        populatePicture(picture, file, order, cover != null ? cover : false);
         return pictureRepository.save(picture);
     }
 
@@ -69,20 +68,25 @@ public class PictureServiceImpl implements IPictureService {
             }
         }
 
-        Picture fileData = storeFile(file);
-        existing.setUrl(fileData.getUrl());
-        existing.setPath(fileData.getPath());
-        existing.setFileName(fileData.getFileName());
-        existing.setMimeType(fileData.getMimeType());
-        existing.setSize(fileData.getSize());
-        if (order != null) {
-            existing.setOrder(order);
-        }
-        if (cover != null) {
-            existing.setCover(cover);
-        }
+        populatePicture(
+                existing,
+                file,
+                order != null ? order : existing.getOrder(),
+                cover != null ? cover : existing.getCover()
+        );
 
         return pictureRepository.save(existing);
+    }
+
+    private void populatePicture(Picture target, MultipartFile file, Integer order, Boolean cover) {
+        Picture fileData = storeFile(file);
+        target.setUrl(fileData.getUrl());
+        target.setPath(fileData.getPath());
+        target.setFileName(fileData.getFileName());
+        target.setMimeType(fileData.getMimeType());
+        target.setSize(fileData.getSize());
+        target.setOrder(order);
+        target.setCover(cover);
     }
 
     private Picture storeFile(MultipartFile file) {


### PR DESCRIPTION
## Summary
- document multipart update method in `IPictureService`
- share picture file handling across create and update
- clarify controller endpoint for multipart picture updates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6890ce4f3d24832f89c1be803387964a