### PR TITLE
Add product attribute catalog and attribute management

### DIFF
--- a/src/main/java/com/ahumadamob/common/DataType.java
+++ b/src/main/java/com/ahumadamob/common/DataType.java
@@ -1,0 +1,8 @@
+package com.ahumadamob.common;
+
+public enum DataType {
+    TEXT,
+    NUMERIC,
+    BOOLEAN,
+    DATE
+}

--- a/src/main/java/com/ahumadamob/common/TipoDato.java
+++ b/src/main/java/com/ahumadamob/common/TipoDato.java
@@ -1,8 +1,0 @@
-package com.ahumadamob.common;
-
-public enum TipoDato {
-    TEXTO,
-    NUMERICO,
-    BOOLEANO,
-    FECHA
-}

--- a/src/main/java/com/ahumadamob/common/TipoDato.java
+++ b/src/main/java/com/ahumadamob/common/TipoDato.java
@@ -1,0 +1,8 @@
+package com.ahumadamob.common;
+
+public enum TipoDato {
+    TEXTO,
+    NUMERICO,
+    BOOLEANO,
+    FECHA
+}

--- a/src/main/java/com/ahumadamob/controller/CatalogoAtributoController.java
+++ b/src/main/java/com/ahumadamob/controller/CatalogoAtributoController.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.controller;
+
+import com.ahumadamob.common.ResponseUtils;
+import com.ahumadamob.dto.ApiSuccessResponseDto;
+import com.ahumadamob.dto.CatalogoAtributoRequestDto;
+import com.ahumadamob.dto.CatalogoAtributoResponseDto;
+import com.ahumadamob.entity.CatalogoAtributo;
+import com.ahumadamob.mapper.CatalogoAtributoMapper;
+import com.ahumadamob.service.ICatalogoAtributoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/catalogo-atributos")
+@CrossOrigin(origins = "http://localhost:4200")
+public class CatalogoAtributoController {
+
+    @Autowired
+    private ICatalogoAtributoService catalogoAtributoService;
+
+    @Autowired
+    private CatalogoAtributoMapper catalogoAtributoMapper;
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponseDto<List<CatalogoAtributoResponseDto>>> getAll() {
+        List<CatalogoAtributo> list = catalogoAtributoService.findAll();
+        List<CatalogoAtributoResponseDto> dtoList = list.stream()
+                .map(catalogoAtributoMapper::toResponseDto)
+                .toList();
+        return ResponseUtils.ok(dtoList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<CatalogoAtributoResponseDto>> getById(@PathVariable Long id) {
+        CatalogoAtributo entity = catalogoAtributoService.findById(id);
+        CatalogoAtributoResponseDto dto = catalogoAtributoMapper.toResponseDto(entity);
+        return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponseDto<CatalogoAtributoResponseDto>> create(@Validated @RequestBody CatalogoAtributoRequestDto request) {
+        CatalogoAtributo entity = catalogoAtributoMapper.toEntity(request);
+        CatalogoAtributo created = catalogoAtributoService.create(entity);
+        CatalogoAtributoResponseDto dto = catalogoAtributoMapper.toResponseDto(created);
+        return ResponseUtils.created(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<CatalogoAtributoResponseDto>> update(@PathVariable Long id, @Validated @RequestBody CatalogoAtributoRequestDto request) {
+        catalogoAtributoService.findById(id); // verify existence
+        CatalogoAtributo entity = catalogoAtributoMapper.toEntity(request);
+        entity.setId(id);
+        CatalogoAtributo updated = catalogoAtributoService.update(entity);
+        CatalogoAtributoResponseDto dto = catalogoAtributoMapper.toResponseDto(updated);
+        return ResponseUtils.updated(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        catalogoAtributoService.findById(id); // verify existence
+        catalogoAtributoService.deleteById(id);
+        return ResponseUtils.deleted();
+    }
+}

--- a/src/main/java/com/ahumadamob/controller/ProductoAtributoController.java
+++ b/src/main/java/com/ahumadamob/controller/ProductoAtributoController.java
@@ -1,0 +1,68 @@
+package com.ahumadamob.controller;
+
+import com.ahumadamob.common.ResponseUtils;
+import com.ahumadamob.dto.ApiSuccessResponseDto;
+import com.ahumadamob.dto.ProductoAtributoRequestDto;
+import com.ahumadamob.dto.ProductoAtributoResponseDto;
+import com.ahumadamob.entity.ProductoAtributo;
+import com.ahumadamob.mapper.ProductoAtributoMapper;
+import com.ahumadamob.service.IProductoAtributoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/producto-atributos")
+@CrossOrigin(origins = "http://localhost:4200")
+public class ProductoAtributoController {
+
+    @Autowired
+    private IProductoAtributoService productoAtributoService;
+
+    @Autowired
+    private ProductoAtributoMapper productoAtributoMapper;
+
+    @GetMapping
+    public ResponseEntity<ApiSuccessResponseDto<List<ProductoAtributoResponseDto>>> getAll() {
+        List<ProductoAtributo> list = productoAtributoService.findAll();
+        List<ProductoAtributoResponseDto> dtoList = list.stream()
+                .map(productoAtributoMapper::toResponseDto)
+                .toList();
+        return ResponseUtils.ok(dtoList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<ProductoAtributoResponseDto>> getById(@PathVariable Long id) {
+        ProductoAtributo entity = productoAtributoService.findById(id);
+        ProductoAtributoResponseDto dto = productoAtributoMapper.toResponseDto(entity);
+        return ResponseUtils.ok(dto);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiSuccessResponseDto<ProductoAtributoResponseDto>> create(@Validated @RequestBody ProductoAtributoRequestDto request) {
+        ProductoAtributo entity = productoAtributoMapper.toEntity(request);
+        ProductoAtributo created = productoAtributoService.create(entity);
+        ProductoAtributoResponseDto dto = productoAtributoMapper.toResponseDto(created);
+        return ResponseUtils.created(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<ProductoAtributoResponseDto>> update(@PathVariable Long id, @Validated @RequestBody ProductoAtributoRequestDto request) {
+        productoAtributoService.findById(id); // verify existence
+        ProductoAtributo entity = productoAtributoMapper.toEntity(request);
+        entity.setId(id);
+        ProductoAtributo updated = productoAtributoService.update(entity);
+        ProductoAtributoResponseDto dto = productoAtributoMapper.toResponseDto(updated);
+        return ResponseUtils.updated(dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiSuccessResponseDto<Void>> delete(@PathVariable Long id) {
+        productoAtributoService.findById(id); // verify existence
+        productoAtributoService.deleteById(id);
+        return ResponseUtils.deleted();
+    }
+}

--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
@@ -1,6 +1,6 @@
 package com.ahumadamob.dto;
 
-import com.ahumadamob.common.TipoDato;
+import com.ahumadamob.common.DataType;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +18,7 @@ public class CatalogoAtributoRequestDto {
     private String nombre;
 
     @NotNull
-    private TipoDato tipoDato;
+    private DataType dataType;
 
     @Size(max = 32)
     private String unidad;

--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
@@ -1,0 +1,31 @@
+package com.ahumadamob.dto;
+
+import com.ahumadamob.common.TipoDato;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CatalogoAtributoRequestDto {
+
+    @NotBlank
+    @Size(max = 64)
+    private String nombre;
+
+    @NotNull
+    private TipoDato tipoDato;
+
+    @Size(max = 32)
+    private String unidad;
+
+    @Size(max = 255)
+    private String descripcion;
+
+    @NotNull
+    private Boolean activo;
+}

--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
@@ -1,6 +1,6 @@
 package com.ahumadamob.dto;
 
-import com.ahumadamob.common.TipoDato;
+import com.ahumadamob.common.DataType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class CatalogoAtributoResponseDto {
     private Long id;
     private String nombre;
-    private TipoDato tipoDato;
+    private DataType dataType;
     private String unidad;
     private String descripcion;
     private Boolean activo;

--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
@@ -1,0 +1,20 @@
+package com.ahumadamob.dto;
+
+import com.ahumadamob.common.TipoDato;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CatalogoAtributoResponseDto {
+    private Long id;
+    private String nombre;
+    private TipoDato tipoDato;
+    private String unidad;
+    private String descripcion;
+    private Boolean activo;
+}

--- a/src/main/java/com/ahumadamob/dto/ProductoAtributoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoAtributoRequestDto.java
@@ -1,0 +1,24 @@
+package com.ahumadamob.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductoAtributoRequestDto {
+
+    @NotNull
+    private Long productoId;
+
+    @NotNull
+    private Long catalogoAtributoId;
+
+    @NotBlank
+    @Size(max = 255)
+    private String valor;
+}

--- a/src/main/java/com/ahumadamob/dto/ProductoAtributoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/ProductoAtributoResponseDto.java
@@ -1,0 +1,17 @@
+package com.ahumadamob.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductoAtributoResponseDto {
+    private Long id;
+    private Long productoId;
+    private CatalogoAtributoResponseDto catalogoAtributo;
+    private String valor;
+}

--- a/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
+++ b/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
@@ -1,0 +1,38 @@
+package com.ahumadamob.entity;
+
+import com.ahumadamob.common.TipoDato;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "catalogo_atributos")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CatalogoAtributo extends BaseEntity {
+
+    @Column(name = "nombre", nullable = false, length = 64)
+    @NotBlank
+    @Size(max = 64)
+    private String nombre;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tipo_dato", nullable = false, length = 20)
+    @NotNull
+    private TipoDato tipoDato;
+
+    @Column(name = "unidad", length = 32)
+    @Size(max = 32)
+    private String unidad;
+
+    @Column(name = "descripcion", length = 255)
+    @Size(max = 255)
+    private String descripcion;
+
+    @Column(name = "activo", nullable = false)
+    @NotNull
+    private Boolean activo;
+}

--- a/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
+++ b/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
@@ -1,6 +1,6 @@
 package com.ahumadamob.entity;
 
-import com.ahumadamob.common.TipoDato;
+import com.ahumadamob.common.DataType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
@@ -20,9 +20,9 @@ public class CatalogoAtributo extends BaseEntity {
     private String nombre;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "tipo_dato", nullable = false, length = 20)
+    @Column(name = "data_type", nullable = false, length = 20)
     @NotNull
-    private TipoDato tipoDato;
+    private DataType dataType;
 
     @Column(name = "unidad", length = 32)
     @Size(max = 32)

--- a/src/main/java/com/ahumadamob/entity/ProductoAtributo.java
+++ b/src/main/java/com/ahumadamob/entity/ProductoAtributo.java
@@ -1,0 +1,30 @@
+package com.ahumadamob.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "producto_atributos")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductoAtributo extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "producto_id", nullable = false)
+    @NotNull
+    private Producto producto;
+
+    @ManyToOne
+    @JoinColumn(name = "catalogo_atributo_id", nullable = false)
+    @NotNull
+    private CatalogoAtributo catalogoAtributo;
+
+    @Column(name = "valor", nullable = false, length = 255)
+    @NotBlank
+    @Size(max = 255)
+    private String valor;
+}

--- a/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
@@ -1,0 +1,37 @@
+package com.ahumadamob.mapper;
+
+import com.ahumadamob.dto.CatalogoAtributoRequestDto;
+import com.ahumadamob.dto.CatalogoAtributoResponseDto;
+import com.ahumadamob.entity.CatalogoAtributo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CatalogoAtributoMapper {
+
+    public CatalogoAtributo toEntity(CatalogoAtributoRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        CatalogoAtributo entity = new CatalogoAtributo();
+        entity.setNombre(dto.getNombre());
+        entity.setTipoDato(dto.getTipoDato());
+        entity.setUnidad(dto.getUnidad());
+        entity.setDescripcion(dto.getDescripcion());
+        entity.setActivo(dto.getActivo());
+        return entity;
+    }
+
+    public CatalogoAtributoResponseDto toResponseDto(CatalogoAtributo entity) {
+        if (entity == null) {
+            return null;
+        }
+        CatalogoAtributoResponseDto dto = new CatalogoAtributoResponseDto();
+        dto.setId(entity.getId());
+        dto.setNombre(entity.getNombre());
+        dto.setTipoDato(entity.getTipoDato());
+        dto.setUnidad(entity.getUnidad());
+        dto.setDescripcion(entity.getDescripcion());
+        dto.setActivo(entity.getActivo());
+        return dto;
+    }
+}

--- a/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
@@ -14,7 +14,7 @@ public class CatalogoAtributoMapper {
         }
         CatalogoAtributo entity = new CatalogoAtributo();
         entity.setNombre(dto.getNombre());
-        entity.setTipoDato(dto.getTipoDato());
+        entity.setDataType(dto.getDataType());
         entity.setUnidad(dto.getUnidad());
         entity.setDescripcion(dto.getDescripcion());
         entity.setActivo(dto.getActivo());
@@ -28,7 +28,7 @@ public class CatalogoAtributoMapper {
         CatalogoAtributoResponseDto dto = new CatalogoAtributoResponseDto();
         dto.setId(entity.getId());
         dto.setNombre(entity.getNombre());
-        dto.setTipoDato(entity.getTipoDato());
+        dto.setDataType(entity.getDataType());
         dto.setUnidad(entity.getUnidad());
         dto.setDescripcion(entity.getDescripcion());
         dto.setActivo(entity.getActivo());

--- a/src/main/java/com/ahumadamob/mapper/ProductoAtributoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/ProductoAtributoMapper.java
@@ -1,0 +1,49 @@
+package com.ahumadamob.mapper;
+
+import com.ahumadamob.dto.ProductoAtributoRequestDto;
+import com.ahumadamob.dto.ProductoAtributoResponseDto;
+import com.ahumadamob.entity.ProductoAtributo;
+import com.ahumadamob.entity.Producto;
+import com.ahumadamob.entity.CatalogoAtributo;
+import com.ahumadamob.service.IProductoService;
+import com.ahumadamob.service.ICatalogoAtributoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductoAtributoMapper {
+
+    @Autowired
+    private IProductoService productoService;
+
+    @Autowired
+    private ICatalogoAtributoService catalogoAtributoService;
+
+    @Autowired
+    private CatalogoAtributoMapper catalogoAtributoMapper;
+
+    public ProductoAtributo toEntity(ProductoAtributoRequestDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Producto producto = productoService.findById(dto.getProductoId());
+        CatalogoAtributo catalogo = catalogoAtributoService.findById(dto.getCatalogoAtributoId());
+        ProductoAtributo entity = new ProductoAtributo();
+        entity.setProducto(producto);
+        entity.setCatalogoAtributo(catalogo);
+        entity.setValor(dto.getValor());
+        return entity;
+    }
+
+    public ProductoAtributoResponseDto toResponseDto(ProductoAtributo entity) {
+        if (entity == null) {
+            return null;
+        }
+        ProductoAtributoResponseDto dto = new ProductoAtributoResponseDto();
+        dto.setId(entity.getId());
+        dto.setProductoId(entity.getProducto().getId());
+        dto.setCatalogoAtributo(catalogoAtributoMapper.toResponseDto(entity.getCatalogoAtributo()));
+        dto.setValor(entity.getValor());
+        return dto;
+    }
+}

--- a/src/main/java/com/ahumadamob/repository/CatalogoAtributoRepository.java
+++ b/src/main/java/com/ahumadamob/repository/CatalogoAtributoRepository.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.repository;
+
+import com.ahumadamob.entity.CatalogoAtributo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CatalogoAtributoRepository extends JpaRepository<CatalogoAtributo, Long> {
+}

--- a/src/main/java/com/ahumadamob/repository/ProductoAtributoRepository.java
+++ b/src/main/java/com/ahumadamob/repository/ProductoAtributoRepository.java
@@ -1,0 +1,9 @@
+package com.ahumadamob.repository;
+
+import com.ahumadamob.entity.ProductoAtributo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductoAtributoRepository extends JpaRepository<ProductoAtributo, Long> {
+}

--- a/src/main/java/com/ahumadamob/service/ICatalogoAtributoService.java
+++ b/src/main/java/com/ahumadamob/service/ICatalogoAtributoService.java
@@ -1,0 +1,12 @@
+package com.ahumadamob.service;
+
+import com.ahumadamob.entity.CatalogoAtributo;
+import java.util.List;
+
+public interface ICatalogoAtributoService {
+    List<CatalogoAtributo> findAll();
+    CatalogoAtributo findById(Long id);
+    CatalogoAtributo create(CatalogoAtributo catalogoAtributo);
+    CatalogoAtributo update(CatalogoAtributo catalogoAtributo);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/service/IProductoAtributoService.java
+++ b/src/main/java/com/ahumadamob/service/IProductoAtributoService.java
@@ -1,0 +1,12 @@
+package com.ahumadamob.service;
+
+import com.ahumadamob.entity.ProductoAtributo;
+import java.util.List;
+
+public interface IProductoAtributoService {
+    List<ProductoAtributo> findAll();
+    ProductoAtributo findById(Long id);
+    ProductoAtributo create(ProductoAtributo productoAtributo);
+    ProductoAtributo update(ProductoAtributo productoAtributo);
+    void deleteById(Long id);
+}

--- a/src/main/java/com/ahumadamob/service/jpa/CatalogoAtributoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/CatalogoAtributoServiceImpl.java
@@ -1,0 +1,43 @@
+package com.ahumadamob.service.jpa;
+
+import com.ahumadamob.entity.CatalogoAtributo;
+import com.ahumadamob.exception.EntityNotFoundException;
+import com.ahumadamob.repository.CatalogoAtributoRepository;
+import com.ahumadamob.service.ICatalogoAtributoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CatalogoAtributoServiceImpl implements ICatalogoAtributoService {
+
+    @Autowired
+    private CatalogoAtributoRepository catalogoAtributoRepository;
+
+    @Override
+    public List<CatalogoAtributo> findAll() {
+        return catalogoAtributoRepository.findAll();
+    }
+
+    @Override
+    public CatalogoAtributo findById(Long id) {
+        return catalogoAtributoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("CatalogoAtributo", id));
+    }
+
+    @Override
+    public CatalogoAtributo create(CatalogoAtributo catalogoAtributo) {
+        return catalogoAtributoRepository.save(catalogoAtributo);
+    }
+
+    @Override
+    public CatalogoAtributo update(CatalogoAtributo catalogoAtributo) {
+        return catalogoAtributoRepository.save(catalogoAtributo);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        catalogoAtributoRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/ahumadamob/service/jpa/ProductoAtributoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/ProductoAtributoServiceImpl.java
@@ -1,0 +1,73 @@
+package com.ahumadamob.service.jpa;
+
+import com.ahumadamob.entity.ProductoAtributo;
+import com.ahumadamob.entity.Producto;
+import com.ahumadamob.entity.CatalogoAtributo;
+import com.ahumadamob.exception.EntityNotFoundException;
+import com.ahumadamob.repository.ProductoAtributoRepository;
+import com.ahumadamob.service.IProductoAtributoService;
+import com.ahumadamob.service.IProductoService;
+import com.ahumadamob.service.ICatalogoAtributoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductoAtributoServiceImpl implements IProductoAtributoService {
+
+    @Autowired
+    private ProductoAtributoRepository productoAtributoRepository;
+
+    @Autowired
+    private IProductoService productoService;
+
+    @Autowired
+    private ICatalogoAtributoService catalogoAtributoService;
+
+    @Override
+    public List<ProductoAtributo> findAll() {
+        return productoAtributoRepository.findAll();
+    }
+
+    @Override
+    public ProductoAtributo findById(Long id) {
+        return productoAtributoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("ProductoAtributo", id));
+    }
+
+    @Override
+    public ProductoAtributo create(ProductoAtributo productoAtributo) {
+        Long productoId = productoAtributo.getProducto() != null ? productoAtributo.getProducto().getId() : null;
+        if (productoId != null) {
+            Producto producto = productoService.findById(productoId);
+            productoAtributo.setProducto(producto);
+        }
+        Long catalogoId = productoAtributo.getCatalogoAtributo() != null ? productoAtributo.getCatalogoAtributo().getId() : null;
+        if (catalogoId != null) {
+            CatalogoAtributo catalogo = catalogoAtributoService.findById(catalogoId);
+            productoAtributo.setCatalogoAtributo(catalogo);
+        }
+        return productoAtributoRepository.save(productoAtributo);
+    }
+
+    @Override
+    public ProductoAtributo update(ProductoAtributo productoAtributo) {
+        Long productoId = productoAtributo.getProducto() != null ? productoAtributo.getProducto().getId() : null;
+        if (productoId != null) {
+            Producto producto = productoService.findById(productoId);
+            productoAtributo.setProducto(producto);
+        }
+        Long catalogoId = productoAtributo.getCatalogoAtributo() != null ? productoAtributo.getCatalogoAtributo().getId() : null;
+        if (catalogoId != null) {
+            CatalogoAtributo catalogo = catalogoAtributoService.findById(catalogoId);
+            productoAtributo.setCatalogoAtributo(catalogo);
+        }
+        return productoAtributoRepository.save(productoAtributo);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        productoAtributoRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `TipoDato` enum
- create `CatalogoAtributo` and `ProductoAtributo` entities
- implement repositories, services, mappers, DTOs and controllers for both entities

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68916af9aa58832fbb68dd9d11f83a6c