### PR TITLE
feat: add attribute ordering and range validation

### DIFF
--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoRequestDto.java
@@ -26,6 +26,18 @@ public class CatalogoAtributoRequestDto {
     @Size(max = 255)
     private String descripcion;
 
+    @PositiveOrZero
+    private Integer orden;
+
+    private Double valorMin;
+
+    private Double valorMax;
+
     @NotNull
     private Boolean activo;
+
+    @AssertTrue(message = "valorMin debe ser menor o igual que valorMax")
+    public boolean isValidRange() {
+        return valorMin == null || valorMax == null || valorMin <= valorMax;
+    }
 }

--- a/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
+++ b/src/main/java/com/ahumadamob/dto/CatalogoAtributoResponseDto.java
@@ -16,5 +16,8 @@ public class CatalogoAtributoResponseDto {
     private DataType dataType;
     private String unidad;
     private String descripcion;
+    private Integer orden;
+    private Double valorMin;
+    private Double valorMax;
     private Boolean activo;
 }

--- a/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
+++ b/src/main/java/com/ahumadamob/entity/CatalogoAtributo.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CatalogoAtributo extends BaseEntity {
 
-    @Column(name = "nombre", nullable = false, length = 64)
+    @Column(name = "nombre", nullable = false, length = 64, unique = true)
     @NotBlank
     @Size(max = 64)
     private String nombre;
@@ -31,6 +31,16 @@ public class CatalogoAtributo extends BaseEntity {
     @Column(name = "descripcion", length = 255)
     @Size(max = 255)
     private String descripcion;
+
+    @Column(name = "orden")
+    @Min(0)
+    private Integer orden;
+
+    @Column(name = "valor_min")
+    private Double valorMin;
+
+    @Column(name = "valor_max")
+    private Double valorMax;
 
     @Column(name = "activo", nullable = false)
     @NotNull

--- a/src/main/java/com/ahumadamob/entity/Categoria.java
+++ b/src/main/java/com/ahumadamob/entity/Categoria.java
@@ -19,7 +19,7 @@ import jakarta.validation.constraints.Size;
 @NoArgsConstructor
 public class Categoria extends BaseEntity {
 
-    @Column(name = "nombre", nullable = false, length = 64)
+    @Column(name = "nombre", nullable = false, length = 64, unique = true)
     @NotBlank
     @Size(max = 64)
     private String nombre;

--- a/src/main/java/com/ahumadamob/entity/Producto.java
+++ b/src/main/java/com/ahumadamob/entity/Producto.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Producto extends BaseEntity {
 
-    @Column(name = "nombre", nullable = false, length = 64)
+    @Column(name = "nombre", nullable = false, length = 64, unique = true)
     @NotBlank
     @Size(max = 64)
     private String nombre;

--- a/src/main/java/com/ahumadamob/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahumadamob/exception/GlobalExceptionHandler.java
@@ -69,4 +69,13 @@ public class GlobalExceptionHandler {
                 .build();
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiErrorResponseDto> handleIllegalArgument(IllegalArgumentException ex) {
+        ApiErrorResponseDto response = ApiErrorResponseDto.builder()
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
+++ b/src/main/java/com/ahumadamob/mapper/CatalogoAtributoMapper.java
@@ -17,6 +17,9 @@ public class CatalogoAtributoMapper {
         entity.setDataType(dto.getDataType());
         entity.setUnidad(dto.getUnidad());
         entity.setDescripcion(dto.getDescripcion());
+        entity.setOrden(dto.getOrden());
+        entity.setValorMin(dto.getValorMin());
+        entity.setValorMax(dto.getValorMax());
         entity.setActivo(dto.getActivo());
         return entity;
     }
@@ -31,6 +34,9 @@ public class CatalogoAtributoMapper {
         dto.setDataType(entity.getDataType());
         dto.setUnidad(entity.getUnidad());
         dto.setDescripcion(entity.getDescripcion());
+        dto.setOrden(entity.getOrden());
+        dto.setValorMin(entity.getValorMin());
+        dto.setValorMax(entity.getValorMax());
         dto.setActivo(entity.getActivo());
         return dto;
     }

--- a/src/main/java/com/ahumadamob/service/jpa/CatalogoAtributoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/CatalogoAtributoServiceImpl.java
@@ -28,16 +28,28 @@ public class CatalogoAtributoServiceImpl implements ICatalogoAtributoService {
 
     @Override
     public CatalogoAtributo create(CatalogoAtributo catalogoAtributo) {
+        validate(catalogoAtributo);
         return catalogoAtributoRepository.save(catalogoAtributo);
     }
 
     @Override
     public CatalogoAtributo update(CatalogoAtributo catalogoAtributo) {
+        validate(catalogoAtributo);
         return catalogoAtributoRepository.save(catalogoAtributo);
     }
 
     @Override
     public void deleteById(Long id) {
         catalogoAtributoRepository.deleteById(id);
+    }
+
+    private void validate(CatalogoAtributo catalogoAtributo) {
+        if (catalogoAtributo.getOrden() != null && catalogoAtributo.getOrden() < 0) {
+            throw new IllegalArgumentException("orden debe ser un valor positivo");
+        }
+        if (catalogoAtributo.getValorMin() != null && catalogoAtributo.getValorMax() != null
+                && catalogoAtributo.getValorMin() > catalogoAtributo.getValorMax()) {
+            throw new IllegalArgumentException("valorMin no puede ser mayor que valorMax");
+        }
     }
 }

--- a/src/main/java/com/ahumadamob/service/jpa/ProductoAtributoServiceImpl.java
+++ b/src/main/java/com/ahumadamob/service/jpa/ProductoAtributoServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ahumadamob.service.jpa;
 
+import com.ahumadamob.common.DataType;
 import com.ahumadamob.common.DataTypeUtils;
 import com.ahumadamob.entity.ProductoAtributo;
 import com.ahumadamob.entity.Producto;
@@ -76,8 +77,18 @@ public class ProductoAtributoServiceImpl implements IProductoAtributoService {
 
     private void normalizeValor(ProductoAtributo productoAtributo) {
         if (productoAtributo.getCatalogoAtributo() != null) {
-            var tipo = productoAtributo.getCatalogoAtributo().getDataType();
+            var catalogo = productoAtributo.getCatalogoAtributo();
+            var tipo = catalogo.getDataType();
             var valorNormalizado = DataTypeUtils.normalize(productoAtributo.getValor(), tipo);
+            if (tipo == DataType.NUMERIC) {
+                Double valor = Double.valueOf(valorNormalizado);
+                if (catalogo.getValorMin() != null && valor < catalogo.getValorMin()) {
+                    throw new IllegalArgumentException("valor por debajo de valorMin");
+                }
+                if (catalogo.getValorMax() != null && valor > catalogo.getValorMax()) {
+                    throw new IllegalArgumentException("valor por encima de valorMax");
+                }
+            }
             productoAtributo.setValor(valorNormalizado);
         }
     }


### PR DESCRIPTION
## Summary
- ensure unique `nombre` across catalog attributes, categories and products
- add optional ordering and min/max value metadata to catalog attributes
- validate attribute ranges and add global handler for illegal arguments

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68969acdf734832fa20adebeee2aa744